### PR TITLE
Add sponsor messaging

### DIFF
--- a/Modules/UpendoPrompt/App_LocalResources/Global.resx
+++ b/Modules/UpendoPrompt/App_LocalResources/Global.resx
@@ -710,4 +710,10 @@ disable: Disables the scheduled job if it exists. If it doesn’t exist, it crea
   <data name="Welcome.Text" xml:space="preserve">
     <value>Thank you for using Upendo Prompt. There is no reason to place this module on a page at this time, but it may be necessary in the future.</value>
   </data>
+  <data name="UpendoSponsorMessage.Text" xml:space="preserve">
+    <value>&lt;br&gt;&lt;br&gt;&lt;hr&gt;&lt;br&gt;
+&lt;p style=&quot;color: white;&quot;&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
+&lt;br&gt;
+&lt;p style=&quot;color: white;&quot;&gt;Sponsor Now:  &lt;a href=&quot;https://github.com/sponsors/UpendoVentures&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; style=&quot;color: yellow;&quot;&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
+  </data>
 </root>

--- a/Modules/UpendoPrompt/Commands/ApplyRoles.cs
+++ b/Modules/UpendoPrompt/Commands/ApplyRoles.cs
@@ -49,6 +49,7 @@ using DotNetNuke.Security.Permissions;
 using DotNetNuke.Security.Roles;
 using System.Linq;
 using System.Collections;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -109,7 +110,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
 
                     var output = (string.Format(this.LocalizeString(Constants.LocalizationKeys.AddRoleSuccess), roleNameValue, portalIdValue));
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Output = output,
                         IsError = false

--- a/Modules/UpendoPrompt/Commands/CaptchaMode.cs
+++ b/Modules/UpendoPrompt/Commands/CaptchaMode.cs
@@ -36,6 +36,7 @@ using Dnn.PersonaBar.Library.Prompt.Models;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -99,7 +100,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 // clear DNN cache 
                 DataCache.ClearCache();
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/CompressLogFiles.cs
+++ b/Modules/UpendoPrompt/Commands/CompressLogFiles.cs
@@ -19,6 +19,7 @@ using DotNetNuke.Services.Scheduling;
 using Upendo.Modules.UpendoPrompt.ScheduledJobs.ClearLogsJob;
 using Upendo.Modules.UpendoPrompt.Utility;
 using System.Linq;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -53,7 +54,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     output += Environment.NewLine + schedulerMessage;
                 }
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     Data = new List<PromptMessage>(),

--- a/Modules/UpendoPrompt/Commands/DebugInfo.cs
+++ b/Modules/UpendoPrompt/Commands/DebugInfo.cs
@@ -34,6 +34,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
 
@@ -93,7 +94,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     output = LocalizeString(Constants.LocalizationKeys.DebugDisabled);
                 }
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 { 
                     Records = messages.Count,
                     Data = messages,

--- a/Modules/UpendoPrompt/Commands/DebugMode.cs
+++ b/Modules/UpendoPrompt/Commands/DebugMode.cs
@@ -35,6 +35,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
@@ -88,7 +89,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     output = this.LocalizeString(Constants.LocalizationKeys.DebugOff);
                 }
                 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/DeleteDemoUsers.cs
+++ b/Modules/UpendoPrompt/Commands/DeleteDemoUsers.cs
@@ -42,6 +42,7 @@ using DotNetNuke.Common.Utilities; // added for the commented-out clearing of ca
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using Upendo.Modules.UpendoPrompt.Entities;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -141,7 +142,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 // clear DNN cache 
                 //DataCache.ClearCache();
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     Data = messages,

--- a/Modules/UpendoPrompt/Commands/DeletePackages .cs
+++ b/Modules/UpendoPrompt/Commands/DeletePackages .cs
@@ -34,6 +34,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
@@ -94,7 +95,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                         Message = Constants.LocalizationKeys.ErrorOccurred
                     });
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Data = messages,
@@ -105,7 +106,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 else
                 {
                     // Success!  
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Output = output

--- a/Modules/UpendoPrompt/Commands/DeleteTempFolder.cs
+++ b/Modules/UpendoPrompt/Commands/DeleteTempFolder.cs
@@ -34,6 +34,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
@@ -64,7 +65,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 var output = string.Empty;
                 output = LocalizeString(Constants.LocalizationKeys.TempFolderFilesDeleteSuccess);
                 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Output = output, 

--- a/Modules/UpendoPrompt/Commands/DeleteTestUsers.cs
+++ b/Modules/UpendoPrompt/Commands/DeleteTestUsers.cs
@@ -42,6 +42,7 @@ using DotNetNuke.Common.Utilities; // added for the commented-out clearing of ca
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using Upendo.Modules.UpendoPrompt.Entities;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -87,7 +88,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 // clear DNN cache 
                 //DataCache.ClearCache();
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     Data = messages,

--- a/Modules/UpendoPrompt/Commands/DemoUsers.cs
+++ b/Modules/UpendoPrompt/Commands/DemoUsers.cs
@@ -44,6 +44,7 @@ using DotNetNuke.Entities.Users;
 using Upendo.Modules.UpendoPrompt.Entities;
 using System.Web.Security;
 using System.Text;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -117,7 +118,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 // clear DNN cache 
                 //DataCache.ClearCache();
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     Data = messages,

--- a/Modules/UpendoPrompt/Commands/Deprecated/DebugInfo.cs
+++ b/Modules/UpendoPrompt/Commands/Deprecated/DebugInfo.cs
@@ -45,6 +45,7 @@ using DotNetNuke.Entities.Profile;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
 
@@ -72,7 +73,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
             {
                 var output = string.Format(LocalizeString(Constants.LocalizationKeys.DEPRECATED), "list-debug");
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/Deprecated/DebugMode.cs
+++ b/Modules/UpendoPrompt/Commands/Deprecated/DebugMode.cs
@@ -40,6 +40,7 @@ using DotNetNuke.Entities.Profile;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
 
 namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
@@ -66,7 +67,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
             {
                 var output = string.Format(LocalizeString(Constants.LocalizationKeys.DEPRECATED), "set-debug");
                 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/Deprecated/PopupMode.cs
+++ b/Modules/UpendoPrompt/Commands/Deprecated/PopupMode.cs
@@ -37,6 +37,7 @@ using Dnn.PersonaBar.Library.Prompt.Models;
 using DotNetNuke.Common.Utilities; // added for the commented-out clearing of cache below
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
 {
@@ -101,7 +102,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
             {
                 var output = string.Format(LocalizeString(Constants.LocalizationKeys.DEPRECATED), "set-popups");
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/Deprecated/ThemesUsed.cs
+++ b/Modules/UpendoPrompt/Commands/Deprecated/ThemesUsed.cs
@@ -39,6 +39,7 @@ using DotNetNuke.Entities.Profile;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
@@ -64,7 +65,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands.Deprecated
             {
                 var output = string.Format(LocalizeString(Constants.LocalizationKeys.DEPRECATED), "list-themes");
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/Impersonate.cs
+++ b/Modules/UpendoPrompt/Commands/Impersonate.cs
@@ -40,6 +40,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Security;
 using DotNetNuke.Services.Log.EventLog;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -112,7 +113,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     // no user was found 
                     output = this.LocalizeString(Constants.LocalizationKeys.ImpersonateNoUserFound);
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Output = output,
                         IsError = true
@@ -125,7 +126,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 {
                     output = this.LocalizeString(Constants.LocalizationKeys.ImpersonateNotAuthorized);
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Output = output,
                         IsError = true
@@ -136,7 +137,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
 
                 output = this.LocalizeString(Constants.LocalizationKeys.ImpersonateSuccess);
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/ListAvailablePackages.cs
+++ b/Modules/UpendoPrompt/Commands/ListAvailablePackages.cs
@@ -34,6 +34,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
@@ -66,7 +67,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
 
                 if (recordCount > 0)
                 {
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Data = messages,
@@ -75,7 +76,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 }
                 else
                 {
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Output = output

--- a/Modules/UpendoPrompt/Commands/ListPackages.cs
+++ b/Modules/UpendoPrompt/Commands/ListPackages.cs
@@ -34,6 +34,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Upendo.Modules.UpendoPrompt.Entities;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
@@ -84,7 +85,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     output = string.Concat(output,
                         string.Format(LocalizeString(Constants.LocalizationKeys.FileSizeMessage), folderSize));
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Data = messages,
@@ -93,7 +94,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 }
                 else
                 {
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Records = recordCount,
                         Output = output

--- a/Modules/UpendoPrompt/Commands/PopupMode.cs
+++ b/Modules/UpendoPrompt/Commands/PopupMode.cs
@@ -37,6 +37,7 @@ using Dnn.PersonaBar.Library.Prompt.Models;
 using DotNetNuke.Common.Utilities; // added for the commented-out clearing of cache below
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -136,7 +137,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                     output = string.Format(this.LocalizeString(Constants.LocalizationKeys.PopupDisabled), outputScope);
                 }
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/ResetPassword.cs
+++ b/Modules/UpendoPrompt/Commands/ResetPassword.cs
@@ -44,6 +44,7 @@ using DotNetNuke.Entities.Users;
 using DotNetNuke.Security;
 using DotNetNuke.Security.Roles;
 using DotNetNuke.Services.Log.EventLog;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -155,7 +156,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                             // no user was found 
                             output = this.LocalizeString(Constants.LocalizationKeys.PasswordResetNoUserFound);
 
-                            return new ConsoleResultModel
+                            return new CustomConsoleResultModel
                             {
                                 Output = output,
                                 IsError = true
@@ -177,7 +178,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                             // no role was found 
                             output = this.LocalizeString(Constants.LocalizationKeys.PasswordResetNoRoleFound);
 
-                            return new ConsoleResultModel
+                            return new CustomConsoleResultModel
                             {
                                 Output = output,
                                 IsError = true
@@ -197,7 +198,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                             // no portal was found 
                             output = this.LocalizeString(Constants.LocalizationKeys.PasswordResetNoPortalFound);
 
-                            return new ConsoleResultModel
+                            return new CustomConsoleResultModel
                             {
                                 Output = output,
                                 IsError = true
@@ -216,7 +217,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 {
                     output = this.LocalizeString(Constants.LocalizationKeys.ResetPasswordNotAuthorized);
 
-                    return new ConsoleResultModel
+                    return new CustomConsoleResultModel
                     {
                         Output = output,
                         IsError = true
@@ -235,7 +236,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
 
                 output = this.LocalizeString(Constants.LocalizationKeys.ResetPasswordSuccess);
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     IsError = false

--- a/Modules/UpendoPrompt/Commands/TestUsers.cs
+++ b/Modules/UpendoPrompt/Commands/TestUsers.cs
@@ -44,6 +44,7 @@ using DotNetNuke.Entities.Users;
 using Upendo.Modules.UpendoPrompt.Entities;
 using System.Web.Security;
 using DotNetNuke.UI.UserControls;
+using Upendo.Modules.UpendoPrompt.Custom;
 
 namespace Upendo.Modules.UpendoPrompt.Commands
 {
@@ -108,7 +109,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 // clear DNN cache 
                 //DataCache.ClearCache();
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Output = output,
                     Data = messages,

--- a/Modules/UpendoPrompt/Commands/ThemesUsed.cs
+++ b/Modules/UpendoPrompt/Commands/ThemesUsed.cs
@@ -32,6 +32,7 @@ using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Instrumentation;
 using Upendo.Modules.UpendoPrompt.Components;
+using Upendo.Modules.UpendoPrompt.Custom;
 using Upendo.Modules.UpendoPrompt.Data;
 using Constants = Upendo.Modules.UpendoPrompt.Components.Constants;
 
@@ -60,7 +61,7 @@ namespace Upendo.Modules.UpendoPrompt.Commands
                 var output = string.Empty;
                 output = LocalizeString(recordCount > 0 ? Constants.LocalizationKeys.RECORDS_SOME : Constants.LocalizationKeys.RECORDS_NONE);
 
-                return new ConsoleResultModel
+                return new CustomConsoleResultModel
                 {
                     Records = recordCount,
                     Data = themesUsed,

--- a/Modules/UpendoPrompt/Components/Constants.cs
+++ b/Modules/UpendoPrompt/Components/Constants.cs
@@ -146,6 +146,7 @@ namespace Upendo.Modules.UpendoPrompt.Components
             public const string SchedulerDisabled = "Prompt_SchedulerDisabled";
             public const string SchedulerNotFound = "Prompt_SchedulerNotFound";
 
+            public const string UpendoSponsorMessage = "UpendoSponsorMessage";
         }
 
         public static class Procedures

--- a/Modules/UpendoPrompt/Custom/CustomConsoleResultModel.cs
+++ b/Modules/UpendoPrompt/Custom/CustomConsoleResultModel.cs
@@ -1,0 +1,31 @@
+﻿using Dnn.PersonaBar.Library.Prompt.Models;
+using DotNetNuke.Services.Localization;
+using Upendo.Modules.UpendoPrompt.Components;
+
+
+namespace Upendo.Modules.UpendoPrompt.Custom
+{
+    public class CustomConsoleResultModel : ConsoleResultModel
+    {
+        public CustomConsoleResultModel()
+        {
+        }
+
+        public CustomConsoleResultModel(string output) : base(output)
+        {
+        }
+
+        public new string Output
+        {
+            get => base.Output; 
+            set => base.Output = ModifyOutput(value); 
+        }
+
+        private static string ModifyOutput(string output)
+        {
+            var upendoSponsorMessage = Localization.GetString(Constants.LocalizationKeys.UpendoSponsorMessage, Constants.PromptLocalResourceFile);
+            return $"{output}{upendoSponsorMessage}";
+        }
+
+    }
+}

--- a/Modules/UpendoPrompt/Upendo.Modules.UpendoPrompt.csproj
+++ b/Modules/UpendoPrompt/Upendo.Modules.UpendoPrompt.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Components\PromptBase.cs" />
     <Compile Include="Components\TempFolderController.cs" />
     <Compile Include="Controllers\ExtensionsController.cs" />
+    <Compile Include="Custom\CustomConsoleResultModel.cs" />
     <Compile Include="Data\DataAccess.cs" />
     <Compile Include="Entities\AvailablePackagesDto.cs" />
     <Compile Include="Entities\Interfaces\ITestUser.cs" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR, the sponsor message was added after each successful `Upendo-Dnn-Prompt` command.  

To achieve this, I developed a custom class called `CustomConsoleResultModel`, which inherits from `ConsoleResultModel`, with the goal of centralizing the management of output messages. This allows any future modifications to the messages to be easily made in this class.  

The sponsor message was created in HTML format and stored in the `Global.resx` resource file, ensuring compatibility with multiple languages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have compiled the module with the changes and tested it on a clean installation of **DNN 9.13.08**. Everything worked as expected.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0959b881-2bb5-4a2f-bcba-7705437bd142)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.