### PR TITLE
Turn off admin message setting

### DIFF
--- a/Modules/UpendoPrompt/App_LocalResources/Global.resx
+++ b/Modules/UpendoPrompt/App_LocalResources/Global.resx
@@ -717,7 +717,7 @@ disable: Disables the scheduled job if it exists. If it doesn’t exist, it crea
     <value>&lt;br&gt;&lt;br&gt;&lt;hr&gt;&lt;br&gt;
 &lt;p style="color: white;"&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
 &lt;br&gt;
-&lt;p style="color: white;"&gt;Sponsor Now:  &lt;a href="https://github.com/sponsors/UpendoVentures" target="_blank" rel="noopener noreferrer" style="color: yellow;"&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
+&lt;p style="color: white;"&gt;Sponsor Now:  &lt;a href="https://github.com/sponsors/UpendoVentures" target="_blank" rel="noopener noreferrer" style="color: #AAA;"&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
   </data>
   <data name="DisableAdminMessageResult.Text" xml:space="preserve">
     <value>Successfully updated {0} modules to hide the admin message.</value>

--- a/Modules/UpendoPrompt/App_LocalResources/Global.resx
+++ b/Modules/UpendoPrompt/App_LocalResources/Global.resx
@@ -170,6 +170,9 @@ disable: Disables the scheduled job if it exists. If it doesn’t exist, it crea
   <data name="DeleteTestUsers.Text" xml:space="preserve">
     <value>Allows you to delete the user accounts created using the `set-testusers` command, in bulk.</value>
   </data>
+  <data name="DisableAdminMessage.Text" xml:space="preserve">
+    <value>Allows you to disable the admin message setting (hideadminborder) for all modules across the site in bulk.</value>
+  </data>
   <data name="DeleteUserNotNeeded.Text" xml:space="preserve">
     <value>User account does not exist, not deleted:  {0} {1} ({2}).</value>
   </data>
@@ -712,8 +715,11 @@ disable: Disables the scheduled job if it exists. If it doesn’t exist, it crea
   </data>
   <data name="UpendoSponsorMessage.Text" xml:space="preserve">
     <value>&lt;br&gt;&lt;br&gt;&lt;hr&gt;&lt;br&gt;
-&lt;p style=&quot;color: white;&quot;&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
+&lt;p style="color: white;"&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
 &lt;br&gt;
-&lt;p style=&quot;color: white;&quot;&gt;Sponsor Now:  &lt;a href=&quot;https://github.com/sponsors/UpendoVentures&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; style=&quot;color: yellow;&quot;&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
+&lt;p style="color: white;"&gt;Sponsor Now:  &lt;a href="https://github.com/sponsors/UpendoVentures" target="_blank" rel="noopener noreferrer" style="color: yellow;"&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
+  </data>
+  <data name="DisableAdminMessageResult.Text" xml:space="preserve">
+    <value>Successfully updated {0} modules to hide the admin message.</value>
   </data>
 </root>

--- a/Modules/UpendoPrompt/App_LocalResources/Global.resx
+++ b/Modules/UpendoPrompt/App_LocalResources/Global.resx
@@ -715,9 +715,9 @@ disable: Disables the scheduled job if it exists. If it doesn’t exist, it crea
   </data>
   <data name="UpendoSponsorMessage.Text" xml:space="preserve">
     <value>&lt;br&gt;&lt;br&gt;&lt;hr&gt;&lt;br&gt;
-&lt;p style="color: white;"&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
+&lt;p style="color: #AAA;"&gt;This Prompt command is maintained by Upendo Ventures. If you haven’t already, please consider becoming a sponsor to help us maintain this project, and others.&lt;/p&gt;
 &lt;br&gt;
-&lt;p style="color: white;"&gt;Sponsor Now:  &lt;a href="https://github.com/sponsors/UpendoVentures" target="_blank" rel="noopener noreferrer" style="color: #AAA;"&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
+&lt;p style="color: #AAA;"&gt;Sponsor Now:  &lt;a href="https://github.com/sponsors/UpendoVentures" target="_blank" rel="noopener noreferrer" style="color: #AAA;"&gt;Upendo Ventures&lt;/a&gt;&lt;/p&gt;</value>
   </data>
   <data name="DisableAdminMessageResult.Text" xml:space="preserve">
     <value>Successfully updated {0} modules to hide the admin message.</value>

--- a/Modules/UpendoPrompt/Commands/DisableAdminMessage.cs
+++ b/Modules/UpendoPrompt/Commands/DisableAdminMessage.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using DotNetNuke.Entities.Modules;
+using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Instrumentation;
+using Dnn.PersonaBar.Library.Prompt;
+using Dnn.PersonaBar.Library.Prompt.Attributes;
+using Dnn.PersonaBar.Library.Prompt.Models;
+using Upendo.Modules.UpendoPrompt.Components;
+using System.Linq;
+using Upendo.Modules.UpendoPrompt.Custom;
+using DotNetNuke.Common.Utilities;
+
+namespace Upendo.Modules.UpendoPrompt.Commands
+{
+    [ConsoleCommand("disable-adminmessage",Constants.PromptCategory, "DisableAdminMessage")]
+    public class DisableAdminMessage : PromptBase, IConsoleCommand
+    {
+        private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(DisableAdminMessage));
+
+        public override ConsoleResultModel Run()
+        {
+            try
+            {
+                DataCache.ClearCache();
+
+                // Get the list of all modules in the portal
+                var modules = ModuleController.Instance.GetModules(this.PortalId);
+                int updatedCount = 0;
+
+                foreach (ModuleInfo module in modules)
+                {
+                    if (module != null && module.TabModuleID > 0)
+                    {                       
+                        // Retrieve the current value of the "hideadminborder" setting for the module
+                        var currentSetting = module.TabModuleSettings.ContainsKey("hideadminborder")
+                            ? module.TabModuleSettings["hideadminborder"]
+                            : null;
+
+                        // Check if the setting is not set or is not "True"
+                        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+                        {
+                            updatedCount++;
+                            // Update or create the "hideadminborder" setting with the value "True"
+                            ModuleController.Instance.UpdateTabModuleSetting(module.TabModuleID, "hideadminborder", "True");
+                        }
+                    }
+                }
+                var output = string.Format(this.LocalizeString(Constants.LocalizationKeys.DisableAdminMessageResult), updatedCount);
+                return new CustomConsoleResultModel
+                {
+                    Output = output,
+                    IsError = false
+                };
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+                return new ConsoleErrorResultModel(string.Concat(Constants.OutputPrefix, this.LocalizeString(Constants.LocalizationKeys.ErrorOccurred)));
+            }
+        }
+
+        protected override void LogError(Exception ex)
+        {
+            if (ex != null)
+            {
+                Logger.Error(ex.Message, ex);
+                if (ex.InnerException != null)
+                {
+                    Logger.Error(ex.InnerException.Message, ex.InnerException);
+                }
+            }
+        }
+    }
+}

--- a/Modules/UpendoPrompt/Commands/DisableAdminMessage.cs
+++ b/Modules/UpendoPrompt/Commands/DisableAdminMessage.cs
@@ -22,8 +22,6 @@ namespace Upendo.Modules.UpendoPrompt.Commands
         {
             try
             {
-                DataCache.ClearCache();
-
                 // Get the list of all modules in the portal
                 var modules = ModuleController.Instance.GetModules(this.PortalId);
                 int updatedCount = 0;

--- a/Modules/UpendoPrompt/Components/Constants.cs
+++ b/Modules/UpendoPrompt/Components/Constants.cs
@@ -147,6 +147,8 @@ namespace Upendo.Modules.UpendoPrompt.Components
             public const string SchedulerNotFound = "Prompt_SchedulerNotFound";
 
             public const string UpendoSponsorMessage = "UpendoSponsorMessage";
+
+            public const string DisableAdminMessageResult = "DisableAdminMessageResult";
         }
 
         public static class Procedures

--- a/Modules/UpendoPrompt/Upendo.Modules.UpendoPrompt.csproj
+++ b/Modules/UpendoPrompt/Upendo.Modules.UpendoPrompt.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Commands\DeleteTempFolder.cs" />
     <Compile Include="Commands\DeleteDemoUsers.cs" />
     <Compile Include="Commands\ApplyRoles.cs" />
+    <Compile Include="Commands\DisableAdminMessage.cs" />
     <Compile Include="Commands\TestUsers.cs" />
     <Compile Include="Commands\Deprecated\DebugInfo.cs" />
     <Compile Include="Commands\Deprecated\DebugMode.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #74 

## Description
<!--- Describe your changes in detail -->
This PR adds a new Upendo Prompt command named `disable-adminmessage`. It sets the `hideadminborder ` setting to `True` for all modules if the value is not already correct. Also ensures missing settings are added.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Modules with hideadminborder = "True" → Not updated (correctly skipped)
- Modules with value "False" or any non-"True" → Updated
- Modules missing the setting entirely → Setting was created and set to "True"
- Modules with setting manually deleted in the DB → Setting was recreated on run
- Verified no exceptions thrown, prompt returns success message with count of updated modules

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/736d99ac-078e-4c76-895b-5206346ad6aa)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.